### PR TITLE
Change to Heroku Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/adamakhtar/slack_dj.git
 heroku create my_app_name # note the apps url
 
 # get a free redis instance 
-heroku addons:create redistogo 
+heroku addons:create heroku-redis:hobby-dev
 
 # configure the heroku app by running 
 heroku config:set APP_DOMAIN=my_app_name.herokuapp.com  

--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,5 +1,5 @@
 production:
-  url: <%= ENV['REDISTOGO_URL'] %>
+  url: <%= ENV['REDIS_URL'] %>
 
 development:
   adapter: async


### PR DESCRIPTION
I changed my installation to use Heroku Redis for 2 reasons, they have a 25 connection limit vs Redis To Go's 10 and I'd prefer to keep it all within the same eco system if possible,
